### PR TITLE
Handle paginated bookmark query results

### DIFF
--- a/server/connectors/bookmarks.js
+++ b/server/connectors/bookmarks.js
@@ -90,7 +90,8 @@ function compareBookmarks(bookmark1, bookmark2) {
 
 // Return a promise for the indicated page of results for the given topic.
 function getResultsForPage(topic, pageNumber) {
-  const url = `${RAINDROP_REST_URL}?search=[{"key":"tag","val":"${topic}"}]&perpage=${MAX_BOOKMARKS_PER_PAGE}&page=${pageNumber}`;
+  const escapedTopic = encodeURIComponent(topic);
+  const url = `${RAINDROP_REST_URL}?search=[{"key":"tag","val":"${escapedTopic}"}]&perpage=${MAX_BOOKMARKS_PER_PAGE}&page=${pageNumber}`;
   console.log(`Bookmarks: ${url}`);
   return fetch(url)
   .then(response => response.json());

--- a/server/connectors/bookmarks.js
+++ b/server/connectors/bookmarks.js
@@ -4,39 +4,108 @@
  * The general principle is that this module isolates anything specific to
  * Raindrop. If we were to change to a different bookmarks back-end, this module
  * would get replaced, but much of the rest of the server could stay the same.
+ *
+ * Raindrop bookmark results are paginated: http://raindrop.io/dev/docs#bookmarks.
+ * The first page of results includes a `count` property indicating how many
+ * total results there are. Once we have that, we know how many more pages of
+ * results to ask for.
+ *
+ * To keep the client as simple as possible, we get *all* bookmarks for a given
+ * topic at once. This works at a small scale, but will become slow as we gather
+ * 100s of bookmarks per topic. On the plus side:
+ *
+ * * Since we have server-side caching, once someone visits a page, subsequent
+ *   visitors within the cache interval will immediately get a complete page of
+ *   results.
+ *
+ * * This also means that only our server is hitting Raindrop, reducing the
+ *   degree to which we may annoy them.
+ *
+ * At some point, we'd like to have our own DB of bookmarks, and at that point
+ * should add infinite-scrolling to the client so the client can request only
+ * those results it actually needs to fill the page.
  */
 
 
 const fetch = require('node-fetch');
 
-const RAINDROP_REST_URL = `https://raindrop.io/api/raindrops/2021037`;
+const PRESTERITY_BOOKMARK_COLLECTION_ID = 2021037;
+const RAINDROP_REST_URL = `https://raindrop.io/api/raindrops/${PRESTERITY_BOOKMARK_COLLECTION_ID}`;
 const MAX_BOOKMARKS_PER_PAGE = 40; // Limit imposed by Raindrop.
 
 
+/*
+ * Return a promise for the complete set of bookmarks on the given topic.
+ * The topic is identified with a string: "Trump Cabinet".
+ *
+ * The bookmarks are returned sorted by bookmark title. Since we start bookmark
+ * titles with a date in YYYY.MM.DD format, the bookmarks will also be sorted
+ * by date.
+ */
 function bookmarksForTopic(topic) {
-  const url = `${RAINDROP_REST_URL}?search=[{"key":"tag","val":"${topic}"}]&perpage=${MAX_BOOKMARKS_PER_PAGE}`;
-  console.log(`Bookmarks: ${url}`);
-  return fetch(url)
-  .then(response => response.json())
-  .then(json => {
-    const sorted = json.items.sort(compareItems);
+
+  let bookmarks;
+
+  // Fetch the initial results: page 0.
+  return getResultsForPage(topic, 0)
+  .then(resultPage0 => {
+
+    // Save the page 0 bookmarks.
+    bookmarks = resultPage0.items;
+
+    // The results include a `count` property that gives the total number of
+    // bookmarks. Use this to calculate how many more pages we need fetch.
+    const bookmarkCount = resultPage0.count;
+    const pageCount = Math.ceil(bookmarkCount / MAX_BOOKMARKS_PER_PAGE);
+
+    // Now get pages 1..pageCount.
+    return getResultsForPages(topic, pageCount);
+  })
+  .then(additionalResultPages => {
+
+    // Combine bookmarks from additional pages (if any) with set from page 0.
+    additionalResultPages.forEach(resultPage => {
+      bookmarks = bookmarks.concat(resultPage.items);
+    });
+
+    // Raindrop's sorting facilities are limited, so we sort ourselves.
+    const sorted = bookmarks.sort(compareBookmarks);
+
     return sorted;
   });
 }
 
-// Sort two items by title.
+// Sort two bookmarks by title.
 // Since the title should start with a date like 2017.01.13, sorting by title
 // should produce a chronological sort.
-function compareItems(a, b) {
-  const aValue = a.title ? a.title.toLowerCase() : '';
-  const bValue = b.title ? b.title.toLowerCase() : '';
-  if (aValue < bValue) {
+function compareBookmarks(bookmark1, bookmark2) {
+  if (bookmark1.title < bookmark2.title) {
     return -1;
   }
-  if (aValue > bValue) {
+  if (bookmark1.title > bookmark2.title) {
     return 1;
   }
   return 0;
+}
+
+// Return a promise for the indicated page of results for the given topic.
+function getResultsForPage(topic, pageNumber) {
+  const url = `${RAINDROP_REST_URL}?search=[{"key":"tag","val":"${topic}"}]&perpage=${MAX_BOOKMARKS_PER_PAGE}&page=${pageNumber}`;
+  console.log(`Bookmarks: ${url}`);
+  return fetch(url)
+  .then(response => response.json());
+}
+
+// Return a promise for pages 1..pageCount of bookmarks for the given topic.
+// This does *not* get the bookmarks on page 0. We handle those separately.
+// Accordingly, if pageCount is 0 or 1, this returns a resolved promise for
+// an empty array.
+function getResultsForPages(topic, pageCount) {
+  let promises = [];
+  for (let page = 1; page < pageCount; page++) {
+    promises = promises.concat(getResultsForPage(topic, page));
+  }
+  return Promise.all(promises);
 }
 
 module.exports = {


### PR DESCRIPTION
Our initial Raindrop connector only supported returning a single page of results. Raindrop's maximum number of bookmarks per result page is 40. We're just about to start hitting that ceiling, so soon topic pages will not be showing all their corresponding bookmarks.

This PR fixes that by looking at the first page of results to see if there are more pages, then fetching all of them and merging/sorting the results before returning them.

This is an interim solution. It can probably scale to a handful of pages per given topic, maybe 3–5 pages or 120–200 bookmarks. Eventually we'll get to a point where this will become unacceptably slow. The user experience of scrolling through 100s of Timeline links won't be great either. We'll eventually want both a better client-side UX (most likely some form of infinite-scrolling) and server-side DB. Hopefully, this is good enough for now.